### PR TITLE
fix compiler warnings:

### DIFF
--- a/libIME/CandidateListUIElement.h
+++ b/libIME/CandidateListUIElement.h
@@ -8,7 +8,6 @@
 namespace Ime {
 
 class CandidateListUIElement:
-	public ITfUIElement,
 	public ITfCandidateListUIElement {
 public:
 	CandidateListUIElement(ITfContext* context);

--- a/libIME/CandidateWindow.cpp
+++ b/libIME/CandidateWindow.cpp
@@ -267,7 +267,6 @@ void CandidateWindow::paintItem(HDC hDC, int i,  int x, int y) {
 	::SetTextColor(hDC, oldColor); // restore text color
 
 	// paint the candidate string
-	SIZE candidateSize;
 	wstring& item = items_.at(i);
 	textRect.left += selKeyWidth_;
 	textRect.right = textRect.left + textWidth_;

--- a/libIME/TextService.h
+++ b/libIME/TextService.h
@@ -43,7 +43,6 @@ class LangBarButton;
 
 class TextService:
 	// TSF interfaces
-	public ITfTextInputProcessor,
 	public ITfTextInputProcessorEx,
 	// event sinks
 	public ITfThreadMgrEventSink,


### PR DESCRIPTION
 warning C4584: 'Ime::TextService' : base-class 'ITfTextInputProcessor' is already a base-class of 'ITfTextInputProcessorEx'
 warning C4584: 'Ime::CandidateListUIElement' : base-class 'ITfUIElement' is already a base-class of 'ITfCandidateListUIElement'
 warning C4101: 'candidateSize' : unreferenced local variable
