### PR TITLE
Update ChewingTextService.cpp for output define string(ctrl1~ctrl9)

### DIFF
--- a/ChewingTextService/ChewingTextService.cpp
+++ b/ChewingTextService/ChewingTextService.cpp
@@ -26,6 +26,10 @@
 #include "resource.h"
 #include <Shellapi.h>
 #include <sys/stat.h>
+#include <fstream>
+#include <ostream>
+#include <codecvt>
+
 
 using namespace std;
 
@@ -181,7 +185,7 @@ bool TextService::filterKeyDown(Ime::KeyEvent& keyEvent) {
 			// FIXME: we only need Ctrl in composition mode for adding user phrases.
 			// However, if we turn on easy symbol input with Ctrl support later,
 			// we'll need th Ctrl key then.
-			return false;
+			return true;
 		}
 
 		// we always need further processing in full shape mode since all English chars,
@@ -220,6 +224,23 @@ bool TextService::filterKeyDown(Ime::KeyEvent& keyEvent) {
 	return true;
 }
 
+//Detect for nummber
+//ctrl[0] buffer can't be uesd so we put ctrl+1 string to ctrl[1]
+bool ctrlSwitch(UINT charCode,bool *ctrlFlag){
+	if(charCode >= '1' && charCode <= '9'){
+		ctrlFlag[charCode - '1'] = 1;
+		return true;
+	}	
+	return false;
+}
+
+// convert wstring to UTF-8 string
+std::string wstring_to_utf8 (const std::wstring& str)
+{
+    std::wstring_convert<std::codecvt_utf8<wchar_t>> myconv;
+    return myconv.to_bytes(str);
+}
+
 // virtual
 bool TextService::onKeyDown(Ime::KeyEvent& keyEvent, Ime::EditSession* session) {
 	assert(chewingContext_);
@@ -236,6 +257,32 @@ bool TextService::onKeyDown(Ime::KeyEvent& keyEvent, Ime::EditSession* session) 
 #endif
 
 	UINT charCode = keyEvent.charCode();
+
+	//dirty add varaible	
+	enum Mode {composition_mode, noncomposition_mode};
+	static Mode mode = noncomposition_mode;
+	static bool ctrlFlag[11]={0};	
+	static wstring ctrl[11];
+	static char line[30];
+	static bool readFlag=1;
+	static int  lineNum;
+	
+	//read form ctrl+num string from dictionary.txt
+	std::fstream fs;
+	if(readFlag){
+		fs.open("dictionary.txt",ios::in | ios::app);
+		if(fs){
+			for(int i=0; fs.getline(line, sizeof(line)); i++){
+				ctrl[i] = utf8ToUtf16(line);
+			}
+		}
+		fs.flush();
+		fs.clear(); 
+		fs.close();
+		readFlag=0;
+	}
+
+	
 	if(charCode && isprint(charCode)) { // printable characters (exclude extended keys?)
 		int oldLangMode = ::chewing_get_ChiEngMode(chewingContext_);
 		bool temporaryEnglishMode = false;
@@ -252,8 +299,17 @@ bool TextService::onKeyDown(Ime::KeyEvent& keyEvent, Ime::EditSession* session) 
 				invertCase = true; // need to convert upper case to lower, and vice versa.
 		}
 
-		if(langMode_ == SYMBOL_MODE) { // English mode
-			::chewing_handle_Default(chewingContext_, charCode);
+		// 1.Detect Ctrl + number (0~9) 	
+		if(mode == noncomposition_mode&&keyEvent.isKeyDown(VK_CONTROL) && ctrlSwitch(charCode,ctrlFlag)){ 
+			
+		}
+		else if(langMode_ == SYMBOL_MODE) { // English mode
+			// 2.Detect Ctrl + number (0~9) for English mode
+			if(keyEvent.isKeyDown(VK_CONTROL) && isdigit(charCode) && ctrlSwitch(charCode,ctrlFlag)){ 
+				
+			}
+			else
+				::chewing_handle_Default(chewingContext_, charCode);
 		}
 		else if(temporaryEnglishMode) { // temporary English mode
 			::chewing_set_ChiEngMode(chewingContext_, SYMBOL_MODE); // change to English mode temporarily
@@ -266,13 +322,15 @@ bool TextService::onKeyDown(Ime::KeyEvent& keyEvent, Ime::EditSession* session) 
 			::chewing_set_ChiEngMode(chewingContext_, oldLangMode); // restore previous mode
 		}
 		else { // Chinese mode
+			mode = composition_mode;
 			if(isalpha(charCode)) // alphabets: A-Z
 				::chewing_handle_Default(chewingContext_, tolower(charCode));
 			else if(keyEvent.keyCode() == VK_SPACE) // space key
 				::chewing_handle_Space(chewingContext_);
-			else if(keyEvent.isKeyDown(VK_CONTROL) && isdigit(charCode)) // Ctrl + number (0~9)
+			else if(keyEvent.isKeyDown(VK_CONTROL) && isdigit(charCode)){ // Ctrl + number (0~9)
+				ctrlSwitch(charCode,ctrlFlag);//3.Add string to Ctrl+num of position
 				::chewing_handle_CtrlNum(chewingContext_, charCode);
-			else if(keyEvent.isKeyToggled(VK_NUMLOCK) && keyEvent.keyCode() >= VK_NUMPAD0 && keyEvent.keyCode() <= VK_DIVIDE)
+			}else if(keyEvent.isKeyToggled(VK_NUMLOCK) && keyEvent.keyCode() >= VK_NUMPAD0 && keyEvent.keyCode() <= VK_DIVIDE)
 				// numlock is on, handle numpad keys
 				::chewing_handle_Numlock(chewingContext_, charCode);
 			else { // other keys, no special handling is needed
@@ -366,7 +424,7 @@ bool TextService::onKeyDown(Ime::KeyEvent& keyEvent, Ime::EditSession* session) 
 	}
 
 	// has something to commit
-	if(::chewing_commit_Check(chewingContext_)) {
+	if(mode == composition_mode && ::chewing_commit_Check(chewingContext_)) {
 		char* buf = ::chewing_commit_String(chewingContext_);
 		std::wstring wbuf = utf8ToUtf16(buf);
 		::chewing_free(buf);
@@ -400,24 +458,74 @@ bool TextService::onKeyDown(Ime::KeyEvent& keyEvent, Ime::EditSession* session) 
 		compositionBuf.insert(pos, wbuf);
 	}
 
+
+	 //examine ctrl flag to printf
+	if(mode == noncomposition_mode){
+		for(int i=0;i<9;i++){
+			if( ctrlFlag[i]){
+				//output string ctrl+num when non-composition mode
+				ctrlFlag[i]=0; 
+				setCompositionString(session, ctrl[i+1].c_str(), ctrl[i+1].length());
+				endComposition(session->context());
+			}
+		}
+	}
+
 	// has something in composition buffer
 	if(!compositionBuf.empty()) {
 		if(!isComposing()) { // start the composition
 			startComposition(session->context());
+
 		}
 		setCompositionString(session, compositionBuf.c_str(), compositionBuf.length());
+		
+		
+		// add string to txt
+		if(mode == composition_mode){
+			for(int i=0;i<9;i++){
+				if(ctrlFlag[i]){
+
+					ctrl[i+1].clear();	
+					ctrl[i+1] = compositionBuf;					
+					std::locale::global(std::locale(""));	
+					std::ofstream wf;
+					//ctrl[0] can't be uesd so we write line 1  
+					char *ctrl1="define your string";
+					wf.open("dictionary.txt",std::ios_base::binary );
+					if(wf){
+						std::wstring dd=L"\r\n";
+						wf.write(ctrl1,sizeof(ctrl1)); 							
+						wf.write("\r\n",2); 		
+						for(int i=1; i<10 ;i++){			
+						    ctrl[i]+=dd;
+						    string ctrlTmp=wstring_to_utf8(ctrl[i]);
+						    wf.write(ctrlTmp.c_str() , ctrlTmp.size() ); 							
+						}	
+					}
+				        wf.flush();
+					wf.clear();  
+					wf.close();								
+					readFlag=1;					
+					ctrlFlag[i]=0;	
+				}			
+			}
+		}
+		
+		
+		
 	}
 	else { // nothing left in composition buffer, terminate composition status
 		if(isComposing()) {
 			// clean composition before end it
 			setCompositionString(session, compositionBuf.c_str(), compositionBuf.length());
-
+			
 			// We also need to make sure that the candidate window is not currently shown.
 			// When typing symbols with ` key, it's possible that the composition string empty,
 			// while the candidate window is shown. We should not terminate the composition in this case.
 			if(!showingCandidates())
 				endComposition(session->context());
 		}
+		 mode = noncomposition_mode; 
 	}
 
 	// update cursor pos

--- a/ChewingTextService/ChewingTextService.cpp
+++ b/ChewingTextService/ChewingTextService.cpp
@@ -243,26 +243,27 @@ public:
 
 private:
 	bool  ctrlFlag[10]; //limit 10
-    std::wstring ctrlStr[10];  //limit 10
+	std::wstring ctrlStr[10];  //limit 10
 	bool read;
 };
 
 defString::defString(){
-	 for(int i=0;i<9;i++){
+	for(int i=0;i<9;i++){
 		ctrlFlag[i]=0;
-	 }
-	 read=1;
+	}
+	read=1;
 }
 
 defString::~defString(){
-	 writeToFile();
+	writeToFile();
 }
 
 bool defString::writeToBuf(int num,const std::wstring wBuf){
 	if(wBuf.empty())
-		 return false;
-	 ctrlStr[num]=wBuf;
-	 return true;
+		return false;
+	ctrlStr[num]=wBuf;
+	writeToFile();
+	return true;
 }
 
 
@@ -274,7 +275,7 @@ bool defString::examineCtrlFlag(std::wstring& ctrlBuf){
 			ctrlBuf=ctrlStr[i];
 		}
 	}
-    return -1;
+	return -1;
 }
 
 //call by reference
@@ -317,9 +318,9 @@ bool defString::writeToFile(){
 	}
 
 	// write message to file
-    std::wstring eof=L"\r\n";
+    std::wstring eof=L"\n";
 
-	for(int i=1; i<10 ;i++){
+	for(int i=0; i<10 ;i++){
 		ctrlStr[i]+=eof;
 		string ctrlTmp=wstring_to_utf8(ctrlStr[i]);
 		wf.write(ctrlTmp.c_str() , ctrlTmp.size());
@@ -341,16 +342,18 @@ bool defString::readFromFile(){
 
 	//try to open File
 	//std::ofstream file("example.txt");
-    std::fstream fs("userString.txt");
+	std::fstream fs("userString.txt");
 	if (!fs.is_open())
         throw std::runtime_error("unable to open file");
 
 	// read message from file
-    char buf[30];
+	char buf[30]={'\0'};
 	for(int i=0; fs.getline(buf, sizeof(buf))&&i<10; i++){
-		 ctrlStr[i]=utf8ToUtf16(buf);
+		ctrlStr[i]=utf8ToUtf16(buf);
+		for(int j=0;j<29;j++)
+			 buf[j]='\0';
 	} 
-    read=0;
+	read=0;
 	return true;
 }
 

--- a/ChewingTextService/ChewingTextService.cpp
+++ b/ChewingTextService/ChewingTextService.cpp
@@ -286,14 +286,14 @@ int defString::examineCtrlFlag(){
 			return i;
 		}
 	}
-    return -1;
+	return -1;
 }
 
 // convert wstring to UTF-8 string
 string defString::wstring_to_utf8 (const std::wstring& str)
 {
-    std::wstring_convert<std::codecvt_utf8<wchar_t>> myconv;
-    return myconv.to_bytes(str);
+	std::wstring_convert<std::codecvt_utf8<wchar_t>> myconv;
+	return myconv.to_bytes(str);
 }
 
 
@@ -305,20 +305,16 @@ bool defString::writeToFile(){
 	//lock mutex before accessing file
 	std::lock_guard<std::mutex> lock(mutex);
 
-	//reflush ctrlStr	    
-	//ctrlStr[num].clear();
-	//ctrlStr[num]=buf;
-
 	//try to open File
 	std::locale::global(std::locale(""));	
 	std::ofstream wf("userString.txt");
-    if (!wf.is_open()){
-        throw std::runtime_error("unable to open file");
+        if (!wf.is_open()){
+		throw std::runtime_error("unable to open file");
 		return false;
 	}
 
 	// write message to file
-    std::wstring eof=L"\n";
+	std::wstring eof=L"\n";
 
 	for(int i=0; i<10 ;i++){
 		ctrlStr[i]+=eof;


### PR DESCRIPTION
Now we can save our string to dictionary.txt(C:/Users/usernmae/dictionary.txt) line 1~line 9 (line 0 can't be uesd)and output our string on uncomposition mode.

We will read string from dictoinary.txt  when pressing  first button.
Add changed buffer to dictoinary.txt on composition-mode and
reload ctrl buffer after pressing button next time.

However, we find another problem that '`' will be triggered when press ctrl+1 or ctrl+0 on composition mode.
I don't know how to fix because this behavior has existed before previous version.
