### PR TITLE
Fix for LangProfileInfo struct change.

### DIFF
--- a/ChewingTextService/DllEntry.cpp
+++ b/ChewingTextService/DllEntry.cpp
@@ -53,7 +53,8 @@ STDAPI DllRegisterServer(void) {
 	Ime::LangProfileInfo info;
 	info.name = name;
 	info.profileGuid = g_profileGuid;
-	info.languageId = MAKELANGID(LANG_CHINESE, SUBLANG_CHINESE_TRADITIONAL);
+	info.locale = L"zh-Hant-TW";
+	info.fallbackLocale = L"zh-TW";
 	info.iconIndex = iconIndex;
 	info.iconFile = modulePath;
 


### PR DESCRIPTION
The struct was changed in:
https://github.com/EasyIME/libIME/commit/b298cba01e1167899fdf2fe04a55f780d9f2a31a

The values are from:
https://github.com/EasyIME/PIME/blob/125acd1a17cd12067df10f91c9c8f18e344e89b8/python/input_methods/chewing/ime.json#L5
