### PR TITLE
Revise license page instructions

### DIFF
--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -47,6 +47,8 @@ RequestExecutionLevel admin
 
 ;Pages
 ; license page
+!define MUI_LICENSEPAGE_BUTTON $(^InstallBtn)
+!define MUI_LICENSEPAGE_TEXT_BOTTOM "$(^Name) 使用 GNU Lesser General Public License (LGPL) 2.1。$\n$_CLICK"
 !insertmacro MUI_PAGE_LICENSE "..\COPYING.txt"
 
 ; !insertmacro MUI_PAGE_COMPONENTS


### PR DESCRIPTION
Before:
![before](https://github.com/chewing/windows-chewing-tsf/assets/9395168/b5845a3b-8a01-4d9c-9437-0dc12e3d4d79)
After:
![after](https://github.com/chewing/windows-chewing-tsf/assets/9395168/8dbad546-d996-4ceb-9aa4-2362fe673db4)

There are some concerns about using localized license text: https://www.gnu.org/licenses/gpl-faq.html#GPLTranslations So I didn't change them.

Closes #155.