### PR TITLE
Use tagged version for `ilammy/msvc-dev-cmd`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
+      - uses: ilammy/msvc-dev-cmd@v1
 
       - name: Setup rustup
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           submodules: true
       - name: Configure build for x86
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
+        uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x86
       - name: Build
@@ -43,7 +43,7 @@ jobs:
         with:
           submodules: true
       - name: Configure build for x64
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
+        uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: x64
       - name: Build


### PR DESCRIPTION
So it won't get outdated when there is a new minor release.