### PR TITLE
Clean up CMake scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,9 @@ add_definitions(
 	/D_UNICODE=1 /DUNICODE=1 # do Unicode build
 	/D_CRT_SECURE_NO_WARNINGS # disable warnings about old libc functions
 )
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /utf-8") # set source code encoding to UTF-8
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-") # turn off C++ RTTI
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /utf-8") # set source code encoding to UTF-8
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /GL /Gw")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /GL /Gw")
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")

--- a/ChewingPreferences/CMakeLists.txt
+++ b/ChewingPreferences/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(ChewingPreferences)
+project(ChewingPreferences LANGUAGES CXX)
 
 include_directories(
     ${CMAKE_SOURCE_DIR}

--- a/ChewingPreferences/CMakeLists.txt
+++ b/ChewingPreferences/CMakeLists.txt
@@ -1,8 +1,5 @@
 project(ChewingPreferences)
 
-# http://www.utf8everywhere.org/
-add_definitions(/D_UNICODE=1 /DUNICODE=1)
-
 include_directories(
     ${CMAKE_SOURCE_DIR}
 )

--- a/ChewingTextService/CMakeLists.txt
+++ b/ChewingTextService/CMakeLists.txt
@@ -24,9 +24,6 @@ add_library(ChewingTextService SHARED
     ${PROJECT_SOURCE_DIR}/mainicon.ico
 )
 
-# http://www.utf8everywhere.org/
-target_compile_definitions(ChewingTextService PRIVATE /D_UNICODE=1 /DUNICODE=1)
-
 target_link_libraries(ChewingTextService
     libchewing
     libIME_static

--- a/chewingwrapper/CMakeLists.txt
+++ b/chewingwrapper/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(chewingwrapper)
+project(chewingwrapper LANGUAGES CXX)
 
 if(NOT DEFINED PROJECT_LIBCHEWING OR NOT DEFINED CHEWING_DATA_PREFIX)
 	message(FATAL_ERROR "PROJECT_LIBCHEWING and CHEWING_DATA_PREFIX must be provided")

--- a/chewingwrapper/CMakeLists.txt
+++ b/chewingwrapper/CMakeLists.txt
@@ -4,12 +4,6 @@ if(NOT DEFINED PROJECT_LIBCHEWING OR NOT DEFINED CHEWING_DATA_PREFIX)
 	message(FATAL_ERROR "PROJECT_LIBCHEWING and CHEWING_DATA_PREFIX must be provided")
 endif()
 
-# /wd4819
-# Without BOM, Visual Studio does not treat source file as UTF-8 encoding, thus
-# it will complain about invalid character. Use /wd4819 can suppress this
-# warning.
-set(CMAKE_C_FLAGS "/wd4819 ${CMAKE_C_FLAGS}")
-
 include_directories(
 	${PROJECT_SOURCE_DIR}/include
 	${PROJECT_LIBCHEWING}/include


### PR DESCRIPTION
* build: Remove redundant compile defines
  Those are already defined in the top level build script.
* build: specify source code encoding as UTF-8
  https://learn.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=msvc-170
* build: set LANGUAGES property properly 