### PR TITLE
Integrating with SignPath and AppVeyor

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,117 +6,17 @@ on:
   workflow_dispatch:
 
 jobs:
-  x86:
-    runs-on: windows-latest
-    name: 32-bit Build
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Configure build for x86
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
-        with:
-          arch: x86
-      - name: Build
-        run: |
-          cmake -B x86 -A Win32
-          cmake --build x86 --config Release
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          path: |
-            x86\libchewing\data\*.dat
-            x86\libchewing\data\*.tab
-            x86\ChewingTextService\Release\*.dll
-            x86\libchewing\Release\*.dll
-            x86\ChewingPreferences\Release\*.exe
-            x86\libchewing\chewing-cli.exe
-          name: x86
-          retention-days: 1
-  x64:
-    runs-on: windows-latest
-    name: 64-bit Build
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Configure build for x64
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
-        with:
-          arch: x64
-      - name: Build
-        run: |
-          cmake -B x64 -A x64
-          cmake --build x64 --config Release
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          path: |
-            x64\libchewing\data\*.dat
-            x64\libchewing\data\*.tab
-            x64\ChewingTextService\Release\*.dll
-            x64\libchewing\Release\*.dll
-            x64\ChewingPreferences\Release\*.exe
-            x64\libchewing\chewing-cli.exe
-          name: x64
-          retention-days: 1
-  package:
-    runs-on: windows-latest
-    name: Build Installer
-    needs: [x86, x64]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-      - name: NSIS
-        run: |
-          mkdir nsis
-          copy installer\* nsis\
-          copy COPYING.txt nsis\
-          mkdir nsis\Dictionary
-          copy x64\libchewing\data\*.dat nsis\Dictionary\
-          copy x64\libchewing\data\*.tab nsis\Dictionary\
-          mkdir nsis\x86
-          copy x86\ChewingTextService\Release\*.dll nsis\x86\
-          copy x86\libchewing\Release\*.dll nsis\x86\
-          copy x86\ChewingPreferences\Release\*.exe nsis\
-          copy x86\libchewing\chewing-cli.exe nsis\
-          mkdir nsis\x64
-          copy x64\ChewingTextService\Release\*.dll nsis\x64\
-          copy x64\libchewing\Release\*.dll nsis\x64\
-          cd nsis
-          makensis installer.nsi
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          path: nsis\windows-chewing-tsf.exe
-          name: nsis
-          retention-days: 1
-  upload:
-    name: Update Nightly Release
-    permissions:
-      contents: write
+  tag-nightly:
     runs-on: ubuntu-latest
-    needs: [package]
+    name: "Update Nightly Tag"
     steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v4
+      - name: Create or update tag
+        uses: actions/github-script@v7
         with:
-          name: nsis
-      - name: Compute Checksum
-        run: |
-          sha256sum windows-chewing-tsf.exe > SHA256SUMS.txt
-      - name: Update nightly release
-        uses: andelf/nightly-release@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: nightly
-          prerelease: true
-          name: "Windows Chewing TSF nightly build $$"
-          body: |
-            This is a nightly build of Windows Chewing TSF.
-          files: |
-            ./SHA256SUMS.txt
-            ./windows-chewing-tsf.exe
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/nightly',
+              sha: context.sha
+            })

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,6 @@
 [submodule "libchewing"]
 	path = libchewing
 	url = https://github.com/chewing/libchewing.git
-	branch = release/0.8.x
 [submodule "libIME"]
 	path = libIME
 	url = https://github.com/EasyIME/libIME.git
-	branch = master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,106 @@
+version: "{build}"
+clone_depth: 1
+os: Visual Studio 2022
+platform: x64
+test: false
+environment:
+  SIGN_PATH_TOKEN:
+    secure: w9Tr3wEpZP53yt8gtJ0G+/hUbjJYuyyPjtEGqEgUOeFYyLM0fqoC/OWkJnRkqhgt
+init:
+  - ps: $env:BUILD_YYYYMMDD=(Get-Date).ToString("yyyyMMdd")
+install:
+  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init -yv --default-toolchain stable-x86_64-pc-windows-msvc
+  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+  - rustup target add i686-pc-windows-msvc
+before_build:
+  - git submodule update --init --depth 1
+build_script:
+  - cmake -B x86 -A Win32 -DBUILD_TESTING=OFF
+  - cmake --build x86 --config Release
+  - cmake -B x64 -A x64 -DBUILD_TESTING=OFF
+  - cmake --build x64 --config Release
+  - mkdir dist
+  - mkdir nsis
+  - copy installer\* nsis\
+  - copy COPYING.txt nsis\
+  - mkdir nsis\Dictionary
+  - copy x64\libchewing\data\*.dat nsis\Dictionary\
+  - mkdir nsis\x86
+  - copy x86\ChewingTextService\Release\*.dll nsis\x86\
+  - copy x86\libchewing\Release\*.dll nsis\x86\
+  - copy x86\ChewingPreferences\Release\*.exe nsis\
+  - copy x86\libchewing\chewing-cli.exe nsis\
+  - mkdir nsis\x64
+  - copy x64\ChewingTextService\Release\*.dll nsis\x64\
+  - copy x64\libchewing\Release\*.dll nsis\x64\
+  - cd nsis
+  - makensis installer.nsi
+
+for:
+  - branches:
+      only:
+        - nightly
+    before_build:
+      - git submodule update --init --remote --depth 1
+    after_build:
+      - ps: Install-Module -Name SignPath
+      - ps: |
+          Submit-SigningRequest `
+            -InputArtifactPath "windows-chewing-tsf.exe" `
+            -ApiToken $env:SIGN_PATH_TOKEN `
+            -OrganizationId "e8feb3e7-02b0-4e78-aa0a-f3431f374964" `
+            -ProjectSlug "windows-chewing-tsf" `
+            -SigningPolicySlug "test-signing" `
+            -OutputArtifactPath "..\dist\windows-chewing-tsf.exe" `
+            -WaitForCompletion
+      - ps: (Get-FileHash "..\dist\windows-chewing-tsf.exe" -Algorithm SHA256).Hash | Out-File -FilePath "..\dist\windows-chewing-tsf.exe.sha256" -Encoding ASCII
+      - ps: $env:SHORT_LOG = (git shortlog --since yesterday) -join "`n"
+    artifacts:
+      - path: dist\windows-chewing-tsf.exe
+      - path: dist\windows-chewing-tsf.exe.sha256
+    deploy:
+      - provider: GitHub
+        auth_token:
+          secure: 5ju2Q+JyZpOIAf3igbOK+21y1bGc8BWI5wIa2U9HsnjLAfT5aLKHpjqjnzpK6tJhnRngMWxoRtdEj/YgWgxsZZHelgmvkKpYGI/ENarXAFpGTAU3fLQvJXNugJtltJ1J
+        tag: nightly
+        release: 最新開發版 $(BUILD_YYYYMMDD)
+        description: |
+          This is a nightly build of Windows Chewing TSF.
+
+          windows-chewing-tsf changes:
+          ```
+          $(SHORT_LOG)
+          ```
+
+          **Full Changelog**: https://github.com/chewing/windows-chewing-tsf/compare/1ba881c...nightly
+        artifact: dist\windows-chewing-tsf.exe,dist\windows-chewing-tsf.exe.sha256
+        prerelease: true
+        force_update: true
+  - branches:
+      only:
+        - /v\d+\.\d+\.\d+/
+    after_build:
+      - ps: Install-Module -Name SignPath
+      - ps: |
+          Submit-SigningRequest `
+            -InputArtifactPath "windows-chewing-tsf.exe" `
+            -ApiToken $env:SIGN_PATH_TOKEN `
+            -OrganizationId "e8feb3e7-02b0-4e78-aa0a-f3431f374964" `
+            -ProjectSlug "windows-chewing-tsf" `
+            -SigningPolicySlug "release-signing" `
+            -OutputArtifactPath "..\dist\windows-chewing-tsf.exe" `
+            -WaitForCompletion
+      - ps: (Get-FileHash "..\dist\windows-chewing-tsf.exe" -Algorithm SHA256).Hash | Out-File -FilePath "..\dist\windows-chewing-tsf.exe.sha256" -Encoding ASCII
+    artifacts:
+      - path: dist\windows-chewing-tsf.exe
+      - path: dist\windows-chewing-tsf.exe.sha256
+    deploy:
+      - provider: GitHub
+        auth_token:
+          secure: 5ju2Q+JyZpOIAf3igbOK+24w1i/y1TcIsyIFRsGEGYE1fjKDA27nUIQjc9HR6BWP8Rguh5y5bOFVzTejhyzYBgnP853VPZfMAfST3siZNubS83lO2dsTdQFG0SXpJdmz
+        release: Release v$(APPVEYOR_REPO_BRANCH)
+        description: UPDATE ME
+        artifact: dist\windows-chewing-tsf.exe,dist\windows-chewing-tsf.exe.sha256
+        draft: true
+        force_update: true


### PR DESCRIPTION
I apply to [SignPath Foundation ](https://signpath.org/) to sign our releases. The signed executable will be recognized by Windows as trusted.

Currently SignPath only supports AppVeyor integration (GitHub Actions is experimental); so I setup AppVeyor to replace our nightly and release workflow.

Once we verify the nightly works as expected then they will issue the release certificate. The current [nightly](https://github.com/chewing/windows-chewing-tsf/releases/tag/nightly) tag is already created from this PR.