### PR TITLE
fix: detect user dir even with MIC

### DIFF
--- a/chewing_tip/src/lib.rs
+++ b/chewing_tip/src/lib.rs
@@ -26,7 +26,7 @@ static G_HINSTANCE: AtomicUsize = AtomicUsize::new(0);
 static LOGGER: LazyLock<Option<LoggerHandle>> = LazyLock::new(crate::logging::init_logger);
 
 #[unsafe(no_mangle)]
-extern "stdcall" fn DllMain(
+extern "system" fn DllMain(
     hmodule: *mut c_void,
     ul_reason_for_call: u32,
     _reserved: *const c_void,
@@ -46,7 +46,7 @@ extern "stdcall" fn DllMain(
 }
 
 #[unsafe(no_mangle)]
-extern "stdcall" fn DllGetClassObject(
+extern "system" fn DllGetClassObject(
     _rclsid: *const c_void,
     riid: *const GUID,
     ppv_obj: *mut *mut c_void,

--- a/chewing_tip/src/logging.rs
+++ b/chewing_tip/src/logging.rs
@@ -30,22 +30,21 @@ pub(super) fn init_logger() -> Option<LoggerHandle> {
         .basename("chewing_tip")
         .suppress_timestamp();
     let writer = Box::new(WinDbgLogWriter);
-    match Logger::try_with_env_or_str("warn").and_then(|logger| {
-        logger
-            .log_to_file_and_writer(file_spec, writer)
-            .rotate(
-                Criterion::Size(1024 * 1024),
-                Naming::Numbers,
-                Cleanup::KeepLogFiles(7),
-            )
-            .append()
-            .cleanup_in_background_thread(true)
-            .panic_if_error_channel_is_broken(false)
-            .use_windows_line_ending()
-            .write_mode(WriteMode::BufferAndFlush)
-            .start()
-    }) {
-        Ok(handle) => Some(handle),
-        Err(_) => None,
-    }
+    Logger::try_with_env_or_str("warn")
+        .and_then(|logger| {
+            logger
+                .log_to_file_and_writer(file_spec, writer)
+                .rotate(
+                    Criterion::Size(1024 * 1024),
+                    Naming::Numbers,
+                    Cleanup::KeepLogFiles(7),
+                )
+                .append()
+                .cleanup_in_background_thread(true)
+                .panic_if_error_channel_is_broken(false)
+                .use_windows_line_ending()
+                .write_mode(WriteMode::BufferAndFlush)
+                .start()
+        })
+        .ok()
 }

--- a/chewing_tip/src/ts/chewing.rs
+++ b/chewing_tip/src/ts/chewing.rs
@@ -1254,12 +1254,10 @@ pub(crate) fn user_dir() -> Result<PathBuf> {
     // If the file exists, it will get the PermissionDenied error instead.
     let user_dir_exists = match std::fs::exists(&user_dir) {
         Ok(true) => true,
-        Err(e) => {
-            match e.kind() {
-                ErrorKind::PermissionDenied => true,
-                _ => false,
-            }
-        }
+        Err(e) => match e.kind() {
+            ErrorKind::PermissionDenied => true,
+            _ => false,
+        },
         _ => false,
     };
 


### PR DESCRIPTION
chewing might be loaded into a low mandatory integrity level process (SearchHost.exe).
In that case, it might not be able to check if a file exists using CreateFile
If the file exists, it will get the PermissionDenied error instead.

Fixes #302 