### PR TITLE
refactor(gfx): use WARP renderer and cache the D3DDevice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "chewing-editor"
-version = "25.8.0"
+version = "25.8.1"
 dependencies = [
  "anyhow",
  "chewing",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "chewing-preferences"
-version = "25.8.0"
+version = "25.8.1"
 dependencies = [
  "anyhow",
  "chewing",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "chewing_tip"
-version = "25.8.0"
+version = "25.8.1"
 dependencies = [
  "anyhow",
  "cc",
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "tsfreg"
-version = "25.8.0"
+version = "25.8.1"
 dependencies = [
  "windows",
  "windows-link",

--- a/chewing_tip/src/ts/ui_elements/candidate_list.rs
+++ b/chewing_tip/src/ts/ui_elements/candidate_list.rs
@@ -47,7 +47,7 @@ use windows_core::{
 
 use crate::{
     gfx::{
-        create_device, create_render_target, create_swapchain, create_swapchain_bitmap,
+        create_render_target, create_swapchain, create_swapchain_bitmap, d3d11_device,
         dwrite_family_from_gdi_name, get_dpi_for_window, get_scale_for_window,
         setup_direct_composition,
     },
@@ -166,7 +166,7 @@ impl RenderedView {
             let factory: ID2D1Factory1 =
                 D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, None)?;
             let dwrite_factory: IDWriteFactory1 = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED)?;
-            let device = create_device()?;
+            let device = d3d11_device()?;
             let target = create_render_target(&factory, &device)?;
             let swapchain = create_swapchain(&device, 10, 10)?;
             let dpi = get_dpi_for_window(window.hwnd());

--- a/chewing_tip/src/ts/ui_elements/notification.rs
+++ b/chewing_tip/src/ts/ui_elements/notification.rs
@@ -39,7 +39,7 @@ use windows_core::{
 
 use crate::{
     gfx::{
-        create_device, create_render_target, create_swapchain, create_swapchain_bitmap,
+        create_render_target, create_swapchain, create_swapchain_bitmap, d3d11_device,
         dwrite_family_from_gdi_name, get_dpi_for_window, get_scale_for_window,
         setup_direct_composition,
     },
@@ -153,7 +153,7 @@ impl RenderedView {
             let factory: ID2D1Factory1 =
                 D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, None)?;
             let dwrite_factory: IDWriteFactory1 = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED)?;
-            let device = create_device()?;
+            let device = d3d11_device()?;
             let target = create_render_target(&factory, &device)?;
             let swapchain = create_swapchain(&device, 10, 10)?;
             let dpi = get_dpi_for_window(window.hwnd());


### PR DESCRIPTION
Fixes #419 