### PR TITLE
fix: treat candidate window open as in composing mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
   the same time. (#440)
 - Correctly scale candidate window when main display is HiDPI
 - Input modes are remembered across focus change.
+- Fixed Numpad numbers sometimes can't be used to select candidates.
 
 ### 🚜 Refactor
 

--- a/tip/src/ts/chewing.rs
+++ b/tip/src/ts/chewing.rs
@@ -1126,7 +1126,8 @@ impl ChewingTextService {
     }
 
     fn is_composing(&self) -> bool {
-        self.composition.borrow().is_some()
+        // when candidate window is shown we are composing even without a composition
+        self.composition.borrow().is_some() || self.candidate_list.is_some()
     }
 
     fn init_chewing_context(&mut self) -> anyhow::Result<()> {


### PR DESCRIPTION
Partially fixes #491 