### PR TITLE
fix: disable lang mode processing if CapsLock is on and keyboard is disabled

### DIFF
--- a/tip/src/text_service/mod.rs
+++ b/tip/src/text_service/mod.rs
@@ -5,7 +5,6 @@ use std::cell::{Cell, RefCell};
 use log::{debug, error};
 use windows::Win32::{
     Foundation::{E_UNEXPECTED, FALSE, LPARAM, WPARAM},
-    System::Variant::VARIANT,
     UI::TextServices::*,
 };
 use windows_core::{


### PR DESCRIPTION
Fixes #568 