### PR TITLE
fix(tip): only process case conversion when key is printable

### DIFF
--- a/tip/src/text_service/chewing.rs
+++ b/tip/src/text_service/chewing.rs
@@ -493,6 +493,7 @@ impl ChewingTextService {
         }
         if self.cfg.borrow().chewing_tsf.enable_caps_lock
             && !self.cfg.borrow().chewing_tsf.lock_chinese_on_caps_lock
+            && evt.ksym.is_unicode()
         {
             // need to handle case conversion
             return Ok(true);


### PR DESCRIPTION
Fixes #591 